### PR TITLE
fix: Removed undefined MEDIAPLAYERCOMMAND feature

### DIFF
--- a/src/kodi.cpp
+++ b/src/kodi.cpp
@@ -101,7 +101,6 @@ Kodi::Kodi(const QVariantMap& config, EntitiesInterface* entities, Notifications
                       << "SHUFFLE"
                       << "SEARCH"
                       << "MEDIAPLAYEREPGVIEW"
-                      << "MEDIAPLAYERCOMMAND"
                       << "MEDIAPLAYERREMOTE"
                       << "TVCHANNELLIST";
     addAvailableEntity(m_entityId, "media_player", integrationId(), friendlyName(), supportedFeatures);


### PR DESCRIPTION
This fixes the plugin loading on the remote.
The MEDIAPLAYERCOMMAND feature is not defined in the configuration schema
and I couldn't find support for it in remote-software.