### PR TITLE
Replaced TVheadend authentication header with QUrl credentials

### DIFF
--- a/src/kodi.h
+++ b/src/kodi.h
@@ -143,8 +143,6 @@ class Kodi : public Integration {
     // Kodi auth stuff
     QMap<int, QString>        m_mapKodiChannelNumberToTVHeadendUUID;
     QMap<QString, int>        m_mapTVHeadendUUIDToKodiChannelNumber;
-    QString                   m_tvheadendClientPassword;
-    QString                   m_tvheadendClientUser;
     QList<QVariant>           m_KodiTVChannelList;
     KodiGetCurrentPlayerState m_KodiGetCurrentPlayerState = KodiGetCurrentPlayerState::GetActivePlayers;
     KodiGetCurrentPlayerState m_KodiNextPlayerState = KodiGetCurrentPlayerState::GetActivePlayers;


### PR DESCRIPTION
Use existing `m_tvheadendJSONUrl` QUrl for authentication information instead of dedicated username and password fields.
A QNetworkRequest uses the authentication information in QUrl, the header auth doesn't need to be set.

Since I have no TVheadend server there's a chance that the changed authentication doesn't work. It also depends how QNetworkRequest uses the credentials from the provided QUrl. It works with a secured Kodi, but TVheadend might be different.

Improved logging: use warning level for connection issues and append returned error information.
Note: logging a QUrl containing credentials will only log the username and the password is not exposed.

Please test and feel free to reject this PR if it doesn't work or if you like to keep the auth header.

