### PR TITLE
Use QUrlQuery for TVheadend GET requests

### DIFF
--- a/src/kodi.h
+++ b/src/kodi.h
@@ -183,7 +183,8 @@ class Kodi : public Integration {
     void showepg(int channel);
 
     // get and post requests
-    void tvheadendGetRequest(const QString& path, const QString& method);
+    void tvheadendGetRequest(const QString& path, const QList<QPair<QString, QString> >& queryItems,
+                             const QString& method);
 
     void postRequest(const QString& params, const int& id);
     void postRequest(const QString& function, const QString& jsonstring);


### PR DESCRIPTION
When using QUrl, special characters in the path will automatically be encoded.
Also the query separator `?` will be encoded because QUrl handles query parameters separately with QUrlQuery.